### PR TITLE
KB-10909 | BE | DEV | Enhancement in the create post API to check the profanity.

### DIFF
--- a/src/main/java/com/igot/cb/consumer/ProfanityConsumer.java
+++ b/src/main/java/com/igot/cb/consumer/ProfanityConsumer.java
@@ -1,0 +1,57 @@
+package com.igot.cb.consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.igot.cb.discussion.repository.DiscussionRepository;
+import com.igot.cb.pores.util.Constants;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.concurrent.CompletableFuture;
+
+@Component
+@Slf4j
+public class ProfanityConsumer {
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Autowired
+    private DiscussionRepository discussionRepository;
+
+    /**
+     * Kafka listener for processing profanity check messages.
+     * Extracts contentId and isProfane from the message and updates the discussion record.
+     *
+     * @param textData the Kafka message containing JSON data
+     */
+    @KafkaListener(topics = "${kafka.topic.process.check.content.profanity}", groupId = "${kafka.group.process.check.content.profanity}")
+    public void checkTextContentIsProfane(ConsumerRecord<String, String> textData) {
+        if (StringUtils.hasText(textData.value())) {
+            try {
+                JsonNode textDataNode = mapper.readTree(textData.value());
+                String postId = textDataNode.path(Constants.REQUEST_DATA).path(Constants.METADATA).path(Constants.POST_ID).asText();
+                boolean isProfane = textDataNode.path(Constants.RESPONSE_DATA).path(Constants.RESPONSE_DATA_PATH).path(Constants.IS_PROFANE).asBoolean(false);
+                String profanityResponseJson = textDataNode.toString();
+                // Update the discussion record asynchronously
+                CompletableFuture.runAsync(() -> {
+                    try {
+                        discussionRepository.updateProfanityFieldsByDiscussionId(postId, profanityResponseJson, isProfane);
+                        log.info("Successfully updated profanity fields for PostId: {}", postId);
+                    } catch (Exception ex) {
+                        log.error("Failed to update profanity fields for postId: {}", postId, ex);
+                    }
+                });
+            } catch (JsonProcessingException e) {
+                log.error("Failed to parse JSON from Kafka message: {}", textData.value(), e);
+            }
+        }
+    }
+
+}
+ 

--- a/src/main/java/com/igot/cb/discussion/entity/DiscussionEntity.java
+++ b/src/main/java/com/igot/cb/discussion/entity/DiscussionEntity.java
@@ -33,4 +33,19 @@ public class DiscussionEntity {
     private Timestamp createdOn;
 
     private Timestamp updatedOn;
+
+    @Type(JsonType.class)
+    @Column(columnDefinition = "jsonb")
+    private JsonNode profanityresponse;
+
+    @Column(name = "isprofane")
+    private Boolean isProfane;
+
+    public DiscussionEntity(String discussionId, JsonNode data, Boolean isActive, Timestamp createdOn, Timestamp updatedOn) {
+        this.discussionId = discussionId;
+        this.data = data;
+        this.isActive = isActive;
+        this.createdOn = createdOn;
+        this.updatedOn = updatedOn;
+    }
 }

--- a/src/main/java/com/igot/cb/discussion/repository/DiscussionRepository.java
+++ b/src/main/java/com/igot/cb/discussion/repository/DiscussionRepository.java
@@ -1,9 +1,18 @@
 package com.igot.cb.discussion.repository;
 
 import com.igot.cb.discussion.entity.DiscussionEntity;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DiscussionRepository extends JpaRepository<DiscussionEntity, String>{
+
+    @Modifying
+    @Transactional
+    @Query(value = "UPDATE discussion SET profanityresponse = cast(?2 as jsonb), isprofane = ?3 WHERE discussion_id = ?1", nativeQuery = true)
+    void updateProfanityFieldsByDiscussionId(String discussionId, String profanityResponseJson, Boolean isProfane);
+
 }

--- a/src/main/java/com/igot/cb/pores/util/CbServerProperties.java
+++ b/src/main/java/com/igot/cb/pores/util/CbServerProperties.java
@@ -94,4 +94,13 @@ public class CbServerProperties {
   @Value("${kafka.topic.user.post.count}")
   private String kafkaUserPostCount;
 
+  @Value("${cb.service.registry.base.url}")
+  private String cbServiceRegistryBaseUrl;
+
+  @Value("${cb.registry.textmoderation.api.path}")
+  private String cbRegistryTextModerationApiPath;
+
+  @Value("${cb.discussion.api.key}")
+  private String cbDiscussionApiKey;
+
 }

--- a/src/main/java/com/igot/cb/pores/util/Constants.java
+++ b/src/main/java/com/igot/cb/pores/util/Constants.java
@@ -282,6 +282,10 @@ public class Constants {
     public static final String SERVICE_CODE = "serviceCode";
     public static final String PROFANITY_CHECK = "PROFANITY-CHECK";
     public static final String LANGUAGE_CODE = "languageCode";
+    public static final String REQUEST_DATA = "request_data";
+    public static final String RESPONSE_DATA = "response_data";
+    public static final String RESPONSE_DATA_PATH = "responseData";
+    public static final String IS_PROFANE = "isProfane";
 
     private Constants() {
     }

--- a/src/main/java/com/igot/cb/pores/util/Constants.java
+++ b/src/main/java/com/igot/cb/pores/util/Constants.java
@@ -268,6 +268,20 @@ public class Constants {
     public static final String TAGGED_POST = "TAGGED_POST";
     public static final String ALERT = "ALERT";
     public static final String MENTIONED_USERS = "mentionedUsers";
+    public static final String FETCH_RESULT_CONSTANT = ".fetchResult:";
+    public static final String URI_CONSTANT = "URI: ";
+    public static final String TEXT = "text";
+    public static final String LANGUAGE = "language";
+    public static final String POST_ID = "post_id";
+    public static final String METADATA = "metadata";
+    public static final String CONTENT_TYPE = "content-type";
+    public static final String APPLICATION_JSON = "application/json";
+    public static final String AUTHORIZATION = "Authorization";
+    public static final String HEADER_MAP = "headerMap";
+    public static final String REQUEST_BODY = "requestBody";
+    public static final String SERVICE_CODE = "serviceCode";
+    public static final String PROFANITY_CHECK = "PROFANITY-CHECK";
+    public static final String LANGUAGE_CODE = "languageCode";
 
     private Constants() {
     }

--- a/src/main/java/com/igot/cb/transactional/service/RequestHandlerServiceImpl.java
+++ b/src/main/java/com/igot/cb/transactional/service/RequestHandlerServiceImpl.java
@@ -1,0 +1,110 @@
+package com.igot.cb.transactional.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import com.igot.cb.pores.util.Constants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@SuppressWarnings("unchecked")
+public class RequestHandlerServiceImpl {
+    private Logger log = LoggerFactory.getLogger(RequestHandlerServiceImpl.class);
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    public Map<String, Object> fetchResultUsingPost(String uri, Object request, Map<String, String> headersValues) {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        Map<String, Object> response = new HashMap<>();
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            if (!CollectionUtils.isEmpty(headersValues)) {
+                headersValues.forEach(headers::set);
+            }
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<Object> entity = new HttpEntity<>(request, headers);
+            if (log.isDebugEnabled()) {
+                log.debug("{}\nURI: {}\nRequest: {}", this.getClass().getCanonicalName() + ".fetchResult", uri, mapper.writeValueAsString(request));
+            }
+            response = restTemplate.postForObject(uri, entity, Map.class);
+            if (log.isDebugEnabled()) {
+                log.debug("Response: {}", mapper.writeValueAsString(response));
+            }
+        } catch (HttpClientErrorException hce) {
+            log.error("Error received: {}", hce.getResponseBodyAsString(), hce);
+            try {
+                response = mapper.readValue(hce.getResponseBodyAsString(), new TypeReference<HashMap<String, Object>>() {});
+            } catch (Exception e1) {
+                log.error("Failed to parse error response: {}", e1.getMessage(), e1);
+            }
+        } catch (JsonProcessingException e) {
+            log.error("JSON processing error: {}", e.getMessage(), e);
+            try {
+                log.warn("Error Response: {}", mapper.writeValueAsString(response));
+            } catch (Exception e1) {
+                log.error("Failed to log error response: {}", e1.getMessage(), e1);
+            }
+        } catch (Exception e) {
+            log.error("Unexpected error: {}", e.getMessage(), e);
+        }
+        return response != null ? response : new HashMap<>();
+    }
+
+
+    public Map<String, Object> fetchUsingGetWithHeadersProfile(String uri, Map<String, String> headersValues) {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        Map<String, Object> response = new HashMap<>();
+        try {
+            if (log.isDebugEnabled()) {
+                log.debug("{}{}{}{}",
+                        this.getClass().getCanonicalName(),
+                        Constants.FETCH_RESULT_CONSTANT,
+                        System.lineSeparator(),
+                        Constants.URI_CONSTANT + uri + System.lineSeparator()
+                );
+            }
+            HttpHeaders headers = new HttpHeaders();
+            if (!CollectionUtils.isEmpty(headersValues)) {
+                headersValues.forEach(headers::set);
+            }
+            HttpEntity<Object> entity = new HttpEntity<>(headers);
+            response = restTemplate.exchange(uri, HttpMethod.GET, entity, Map.class).getBody();
+            if (response == null) {
+                response = new HashMap<>();
+            }
+        } catch (HttpClientErrorException e) {
+            log.error("Error received: {}", e.getResponseBodyAsString(), e);
+            try {
+                response = mapper.readValue(e.getResponseBodyAsString(), new TypeReference<HashMap<String, Object>>() {});
+            } catch (Exception e1) {
+                log.error("Failed to parse error response: {}", e1.getMessage(), e1);
+            }
+        } catch (Exception e) {
+            log.error("Unexpected error: {}", e.getMessage(), e);
+            try {
+                log.warn("Error Response: {}", mapper.writeValueAsString(response));
+            } catch (Exception e1) {
+                log.error("Failed to log error response: {}", e1.getMessage(), e1);
+            }
+        }
+        return response;
+    }
+}

--- a/src/main/java/com/igot/cb/transactional/service/RequestHandlerServiceImpl.java
+++ b/src/main/java/com/igot/cb/transactional/service/RequestHandlerServiceImpl.java
@@ -5,13 +5,11 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
-import com.igot.cb.pores.util.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
@@ -29,8 +27,10 @@ public class RequestHandlerServiceImpl {
     @Autowired
     private RestTemplate restTemplate;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     public Map<String, Object> fetchResultUsingPost(String uri, Object request, Map<String, String> headersValues) {
-        ObjectMapper mapper = new ObjectMapper();
         mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         Map<String, Object> response = new HashMap<>();
         try {
@@ -65,46 +65,5 @@ public class RequestHandlerServiceImpl {
             log.error("Unexpected error: {}", e.getMessage(), e);
         }
         return response != null ? response : new HashMap<>();
-    }
-
-
-    public Map<String, Object> fetchUsingGetWithHeadersProfile(String uri, Map<String, String> headersValues) {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
-        Map<String, Object> response = new HashMap<>();
-        try {
-            if (log.isDebugEnabled()) {
-                log.debug("{}{}{}{}",
-                        this.getClass().getCanonicalName(),
-                        Constants.FETCH_RESULT_CONSTANT,
-                        System.lineSeparator(),
-                        Constants.URI_CONSTANT + uri + System.lineSeparator()
-                );
-            }
-            HttpHeaders headers = new HttpHeaders();
-            if (!CollectionUtils.isEmpty(headersValues)) {
-                headersValues.forEach(headers::set);
-            }
-            HttpEntity<Object> entity = new HttpEntity<>(headers);
-            response = restTemplate.exchange(uri, HttpMethod.GET, entity, Map.class).getBody();
-            if (response == null) {
-                response = new HashMap<>();
-            }
-        } catch (HttpClientErrorException e) {
-            log.error("Error received: {}", e.getResponseBodyAsString(), e);
-            try {
-                response = mapper.readValue(e.getResponseBodyAsString(), new TypeReference<HashMap<String, Object>>() {});
-            } catch (Exception e1) {
-                log.error("Failed to parse error response: {}", e1.getMessage(), e1);
-            }
-        } catch (Exception e) {
-            log.error("Unexpected error: {}", e.getMessage(), e);
-            try {
-                log.warn("Error Response: {}", mapper.writeValueAsString(response));
-            } catch (Exception e1) {
-                log.error("Failed to log error response: {}", e1.getMessage(), e1);
-            }
-        }
-        return response;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -96,4 +96,6 @@ cb.service.registry.base.url=http://cb-service-registry:8096
 cb.registry.textmoderation.api.path=serviceregistry/v1/callExternalApi
 cb.discussion.api.key=bearer apiKey
 
+kafka.topic.process.check.content.profanity=dev.process.check.content.profanity
+kafka.group.process.check.content.profanity=dev.process.check.content.profanity.group
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -92,5 +92,8 @@ user.feed.filter.criteriaMapSize=3
 
 
 notification.api.url=http://cb-notification-wrapper-service:8081/notifications/create
+cb.service.registry.base.url=http://cb-service-registry:8096
+cb.registry.textmoderation.api.path=serviceregistry/v1/callExternalApi
+cb.discussion.api.key=bearer apiKey
 
 

--- a/src/test/java/com/igot/cb/consumer/ProfanityConsumerTest.java
+++ b/src/test/java/com/igot/cb/consumer/ProfanityConsumerTest.java
@@ -1,0 +1,128 @@
+package com.igot.cb.consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.igot.cb.discussion.repository.DiscussionRepository;
+import com.igot.cb.pores.util.Constants;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProfanityConsumerTest {
+
+    @InjectMocks
+    private ProfanityConsumer profanityConsumer;
+
+    @Mock
+    private ObjectMapper mapper;
+
+    @Mock
+    private DiscussionRepository discussionRepository;
+
+    @Captor
+    private ArgumentCaptor<String> postIdCaptor;
+
+    @Captor
+    private ArgumentCaptor<String> responseCaptor;
+
+    @Captor
+    private ArgumentCaptor<Boolean> isProfaneCaptor;
+
+    private static final String KAFKA_VALUE = "{\"request_data\":{\"metadata\":{\"post_id\":\"post123\"}},\"response_data\":{\"response\":{\"isProfane\":true}}}";
+
+    @Test
+    void testCheckTextContentIsProfane_Success() throws Exception {
+        ConsumerRecord<String, String> consumerRecord = new ConsumerRecord<>("topic", 0, 0L, null, KAFKA_VALUE);
+
+        JsonNode mockNode = mock(JsonNode.class);
+        JsonNode requestData = mock(JsonNode.class);
+        JsonNode metadata = mock(JsonNode.class);
+        JsonNode responseData = mock(JsonNode.class);
+        JsonNode responsePath = mock(JsonNode.class);
+
+        when(mapper.readTree(KAFKA_VALUE)).thenReturn(mockNode);
+        when(mockNode.path(Constants.REQUEST_DATA)).thenReturn(requestData);
+        when(requestData.path(Constants.METADATA)).thenReturn(metadata);
+        when(metadata.path(Constants.POST_ID)).thenReturn(mock(JsonNode.class));
+        when(metadata.path(Constants.POST_ID).asText()).thenReturn("post123");
+
+        when(mockNode.path(Constants.RESPONSE_DATA)).thenReturn(responseData);
+        when(responseData.path(Constants.RESPONSE_DATA_PATH)).thenReturn(responsePath);
+        when(responsePath.path(Constants.IS_PROFANE)).thenReturn(mock(JsonNode.class));
+        when(responsePath.path(Constants.IS_PROFANE).asBoolean(false)).thenReturn(true);
+
+        when(mockNode.toString()).thenReturn(KAFKA_VALUE);
+
+        profanityConsumer.checkTextContentIsProfane(consumerRecord);
+
+        // Wait for async execution
+        Thread.sleep(200);
+
+        verify(discussionRepository, atLeastOnce()).updateProfanityFieldsByDiscussionId(
+                eq("post123"), eq(KAFKA_VALUE), eq(true)
+        );
+    }
+
+    @Test
+    void testCheckTextContentIsProfane_InvalidJson() throws Exception {
+        ConsumerRecord<String, String> consumerRecord = new ConsumerRecord<>("topic", 0, 0L, null, "invalid_json");
+        when(mapper.readTree("invalid_json")).thenThrow(new JsonProcessingException("error") {});
+
+        profanityConsumer.checkTextContentIsProfane(consumerRecord);
+
+        verifyNoInteractions(discussionRepository);
+    }
+
+    @Test
+    void testCheckTextContentIsProfane_EmptyValue() {
+        ConsumerRecord<String, String> consumerRecord = new ConsumerRecord<>("topic", 0, 0L, null, "");
+        profanityConsumer.checkTextContentIsProfane(consumerRecord);
+        verifyNoInteractions(discussionRepository);
+    }
+
+    @Test
+    void testCheckTextContentIsProfane_RepositoryThrowsException_LogsError() throws Exception {
+        ConsumerRecord<String, String> consumerRecord = new ConsumerRecord<>("topic", 0, 0L, null, KAFKA_VALUE);
+
+        JsonNode mockNode = mock(JsonNode.class);
+        JsonNode requestData = mock(JsonNode.class);
+        JsonNode metadata = mock(JsonNode.class);
+        JsonNode responseData = mock(JsonNode.class);
+        JsonNode responsePath = mock(JsonNode.class);
+
+        when(mapper.readTree(KAFKA_VALUE)).thenReturn(mockNode);
+        when(mockNode.path(Constants.REQUEST_DATA)).thenReturn(requestData);
+        when(requestData.path(Constants.METADATA)).thenReturn(metadata);
+        when(metadata.path(Constants.POST_ID)).thenReturn(mock(JsonNode.class));
+        when(metadata.path(Constants.POST_ID).asText()).thenReturn("post123");
+
+        when(mockNode.path(Constants.RESPONSE_DATA)).thenReturn(responseData);
+        when(responseData.path(Constants.RESPONSE_DATA_PATH)).thenReturn(responsePath);
+        when(responsePath.path(Constants.IS_PROFANE)).thenReturn(mock(JsonNode.class));
+        when(responsePath.path(Constants.IS_PROFANE).asBoolean(false)).thenReturn(true);
+
+        when(mockNode.toString()).thenReturn(KAFKA_VALUE);
+
+        // Simulate exception
+        doThrow(new RuntimeException("DB error")).when(discussionRepository)
+                .updateProfanityFieldsByDiscussionId(anyString(), anyString(), anyBoolean());
+
+        profanityConsumer.checkTextContentIsProfane(consumerRecord);
+
+        // Wait for async execution
+        Thread.sleep(200);
+
+        // You can't directly verify log output with Lombok's @Slf4j, but you can use a library like SystemOutRule,
+        // or refactor to inject a logger. For now, just verify the repository was called and exception didn't propagate.
+        verify(discussionRepository, atLeastOnce()).updateProfanityFieldsByDiscussionId(
+                eq("post123"), eq(KAFKA_VALUE), eq(true)
+        );
+    }
+}

--- a/src/test/java/com/igot/cb/discussion/entity/DiscussionEntityTest.java
+++ b/src/test/java/com/igot/cb/discussion/entity/DiscussionEntityTest.java
@@ -1,0 +1,95 @@
+package com.igot.cb.discussion.entity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DiscussionEntityTest {
+
+    @Test
+    void testNoArgsConstructorAndSettersGetters() throws Exception {
+        DiscussionEntity entity = new DiscussionEntity();
+
+        String discussionId = "d123";
+        Timestamp createdOn = new Timestamp(System.currentTimeMillis());
+        Timestamp updatedOn = new Timestamp(System.currentTimeMillis());
+        Boolean isActive = true;
+        Boolean isProfane = false;
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode data = mapper.readTree("{\"key\": \"value\"}");
+        JsonNode profanityResponse = mapper.readTree("{\"profanity\": false}");
+
+        entity.setDiscussionId(discussionId);
+        entity.setData(data);
+        entity.setIsActive(isActive);
+        entity.setCreatedOn(createdOn);
+        entity.setUpdatedOn(updatedOn);
+        entity.setProfanityresponse(profanityResponse);
+        entity.setIsProfane(isProfane);
+
+        assertEquals(discussionId, entity.getDiscussionId());
+        assertEquals(data, entity.getData());
+        assertEquals(isActive, entity.getIsActive());
+        assertEquals(createdOn, entity.getCreatedOn());
+        assertEquals(updatedOn, entity.getUpdatedOn());
+        assertEquals(profanityResponse, entity.getProfanityresponse());
+        assertEquals(isProfane, entity.getIsProfane());
+    }
+
+    @Test
+    void testAllArgsConstructor() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode data = mapper.readTree("{\"foo\": \"bar\"}");
+        JsonNode profanityResponse = mapper.readTree("{\"profanity\": true}");
+        Timestamp createdOn = new Timestamp(System.currentTimeMillis());
+        Timestamp updatedOn = new Timestamp(System.currentTimeMillis());
+
+        DiscussionEntity entity = new DiscussionEntity(
+                "d456",
+                data,
+                false,
+                createdOn,
+                updatedOn,
+                profanityResponse,
+                true
+        );
+
+        assertEquals("d456", entity.getDiscussionId());
+        assertEquals(data, entity.getData());
+        assertFalse(entity.getIsActive());
+        assertEquals(createdOn, entity.getCreatedOn());
+        assertEquals(updatedOn, entity.getUpdatedOn());
+        assertEquals(profanityResponse, entity.getProfanityresponse());
+        assertTrue(entity.getIsProfane());
+    }
+
+    @Test
+    void testCustomConstructor() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode data = mapper.readTree("{\"baz\": \"qux\"}");
+        Timestamp createdOn = new Timestamp(System.currentTimeMillis());
+        Timestamp updatedOn = new Timestamp(System.currentTimeMillis());
+
+        DiscussionEntity entity = new DiscussionEntity(
+                "d789",
+                data,
+                true,
+                createdOn,
+                updatedOn
+        );
+
+        assertEquals("d789", entity.getDiscussionId());
+        assertEquals(data, entity.getData());
+        assertTrue(entity.getIsActive());
+        assertEquals(createdOn, entity.getCreatedOn());
+        assertEquals(updatedOn, entity.getUpdatedOn());
+        // The following fields should be null as they are not set by this constructor
+        assertNull(entity.getProfanityresponse());
+        assertNull(entity.getIsProfane());
+    }
+}

--- a/src/test/java/com/igot/cb/transactional/service/RequestHandlerServiceImplTest.java
+++ b/src/test/java/com/igot/cb/transactional/service/RequestHandlerServiceImplTest.java
@@ -1,0 +1,260 @@
+package com.igot.cb.transactional.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.slf4j.Logger;
+import org.springframework.http.*;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class RequestHandlerServiceImplTest {
+
+    @InjectMocks
+    private RequestHandlerServiceImpl service;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private Logger log;
+
+    private ObjectMapper mockMapper;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        // Inject a mock logger
+        Field logField = RequestHandlerServiceImpl.class.getDeclaredField("log");
+        logField.setAccessible(true);
+        logField.set(service, log);
+        when(log.isDebugEnabled()).thenReturn(true);
+        mockMapper = mock(ObjectMapper.class);
+        Field mapperField = RequestHandlerServiceImpl.class.getDeclaredField("mapper");
+        mapperField.setAccessible(true);
+        mapperField.set(service, mockMapper);
+    }
+
+    @Test
+    void testFetchResultUsingPost_successWithoutHeaders() throws Exception {
+        Map<String, Object> expectedResponse = Map.of("key", "value");
+        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(expectedResponse);
+        when(mockMapper.writeValueAsString(any())).thenReturn("{}");
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", Map.of("req", "data"), null);
+        assertEquals(expectedResponse, result);
+    }
+
+    @Test
+    void testFetchResultUsingPost_httpClientErrorException_parseSuccess() throws Exception {
+        String errorJson = "{\"error\":\"bad request\"}";
+        Map<String, Object> parsed = Map.of("error", "bad request");
+        HttpClientErrorException hce = mock(HttpClientErrorException.class);
+        when(hce.getResponseBodyAsString()).thenReturn(errorJson);
+        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(Map.class))).thenThrow(hce);
+        when(mockMapper.readValue(eq(errorJson), ArgumentMatchers.<com.fasterxml.jackson.core.type.TypeReference<Map<String, Object>>>any()))
+                .thenReturn(parsed);
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", Map.of(), null);
+        verify(log).error(contains("Error received"), eq(errorJson), eq(hce));
+        assertEquals(parsed, result);
+    }
+
+    @Test
+    void testFetchResultUsingPost_httpClientErrorException_parseFailure() throws Exception {
+        String invalidJson = "not a json";
+        HttpClientErrorException hce = mock(HttpClientErrorException.class);
+        when(hce.getResponseBodyAsString()).thenReturn(invalidJson);
+        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(Map.class))).thenThrow(hce);
+        when(mockMapper.readValue(eq(invalidJson), ArgumentMatchers.<com.fasterxml.jackson.core.type.TypeReference<Map<String, Object>>>any()))
+                .thenThrow(new RuntimeException("parse error"));
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", Map.of(), null);
+        verify(log).error(contains("Error received"), eq(invalidJson), eq(hce));
+        verify(log, atLeastOnce()).error(contains("Failed to parse error response"), any(), any());
+        assertEquals(new HashMap<>(), result);
+    }
+
+    @Test
+    void testFetchResultUsingPost_genericException() throws Exception {
+        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(Map.class)))
+                .thenThrow(new RuntimeException("Unexpected"));
+        when(mockMapper.writeValueAsString(any())).thenReturn("{}");
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", Map.of(), null);
+        verify(log).error(startsWith("Unexpected error"), any(), any());
+        assertEquals(new HashMap<>(), result);
+    }
+
+    @Test
+    void fetchResultUsingPost_handlesNullHeaders() throws Exception {
+        Map<String, Object> expectedResponse = Map.of("result", 1);
+        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(expectedResponse);
+        when(mockMapper.writeValueAsString(any())).thenReturn("{}");
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", Map.of("req", "data"), null);
+        assertEquals(expectedResponse, result);
+    }
+
+    @Test
+    void fetchResultUsingPost_handlesEmptyHeaders() throws Exception {
+        Map<String, Object> expectedResponse = Map.of("result", 2);
+        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(expectedResponse);
+        when(mockMapper.writeValueAsString(any())).thenReturn("{}");
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", Map.of("req", "data"), new HashMap<>());
+        assertEquals(expectedResponse, result);
+    }
+
+    @Test
+    void fetchResultUsingPost_handlesNullRequest() throws Exception {
+        Map<String, Object> expectedResponse = Map.of("result", 3);
+        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(expectedResponse);
+        when(mockMapper.writeValueAsString(any())).thenReturn("{}");
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", null, null);
+        assertEquals(expectedResponse, result);
+    }
+
+    @Test
+    void fetchResultUsingPost_handlesNullUri() throws Exception {
+        when(restTemplate.postForObject(isNull(), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(null);
+        when(mockMapper.writeValueAsString(any())).thenReturn("{}");
+        Map<String, Object> result = service.fetchResultUsingPost(null, Map.of("req", "data"), null);
+        assertEquals(new HashMap<>(), result);
+    }
+
+    @Test
+    void fetchResultUsingPost_returnsEmptyMapWhenResponseIsNull() throws Exception {
+        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(null);
+        when(mockMapper.writeValueAsString(any())).thenReturn("{}");
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", Map.of("req", "data"), null);
+        assertEquals(new HashMap<>(), result);
+    }
+
+    @Test
+    void fetchResultUsingPost_handlesExceptionInErrorResponseParsing() throws Exception {
+        String errorJson = "{invalid json}";
+        HttpClientErrorException hce = mock(HttpClientErrorException.class);
+        when(hce.getResponseBodyAsString()).thenReturn(errorJson);
+        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(Map.class)))
+                .thenThrow(hce);
+        when(mockMapper.readValue(eq(errorJson), ArgumentMatchers.<com.fasterxml.jackson.core.type.TypeReference<Map<String, Object>>>any()))
+                .thenThrow(new RuntimeException("parse error"));
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", Map.of(), null);
+        assertEquals(new HashMap<>(), result);
+    }
+
+    @Test
+    void fetchResultUsingPost_triggersJsonProcessingExceptionAndCoversCatchBlock() throws Exception {
+        when(mockMapper.writeValueAsString(any())).thenThrow(new JsonProcessingException("test") {
+        });
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", Map.of("foo", "bar"), null);
+        assertEquals(new HashMap<>(), result);
+        verify(log).error(contains("JSON processing error"), any(), any());
+    }
+
+    @Test
+    void fetchResultUsingPost_handlesExceptionInLoggingErrorResponse() throws Exception {
+        when(mockMapper.writeValueAsString(any()))
+                .thenReturn("{}") // for request logging
+                .thenThrow(new JsonProcessingException("test") {
+                }); // for error logging
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", Map.of("foo", "bar"), null);
+        assertEquals(new HashMap<>(), result);
+        verify(log).error(contains("JSON processing error"), any(), any());
+        verify(log).error(contains("Failed to log error response"), any(), any());
+    }
+
+
+    @Test
+    void testSuccessfulCall() throws Exception {
+        Map<String, Object> expected = Map.of("key", "value");
+        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(expected);
+        when(mockMapper.writeValueAsString(any())).thenReturn("{}");
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", Map.of("req", "data"), null);
+        assertEquals(expected, result);
+        verify(log, atLeastOnce()).debug(anyString(), any(), any(), any());
+    }
+
+    @Test
+    void testHttpClientErrorException_parsesResponse() throws Exception {
+        String errorJson = "{\"error\":\"bad request\"}";
+        HttpClientErrorException hce = HttpClientErrorException.create(
+                HttpStatus.BAD_REQUEST, "Bad Request", null, errorJson.getBytes(), null
+        );
+        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(Map.class)))
+                .thenThrow(hce);
+        when(mockMapper.readValue(eq(errorJson), any(TypeReference.class)))
+                .thenReturn(Map.of("error", "bad request"));
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", Map.of(), null);
+        assertEquals(Map.of("error", "bad request"), result);
+        verify(log).error(contains("Error received"), any(), eq(hce));
+    }
+
+    @Test
+    void testHttpClientErrorException_parsingFails() throws Exception {
+        String errorJson = "invalid json";
+        HttpClientErrorException hce = HttpClientErrorException.create(
+                HttpStatus.BAD_REQUEST, "Bad Request", null, errorJson.getBytes(), null
+        );
+        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(Map.class)))
+                .thenThrow(hce);
+        when(mockMapper.readValue(eq(errorJson), any(TypeReference.class)))
+                .thenThrow(new RuntimeException("parse error"));
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", Map.of(), null);
+        assertEquals(new HashMap<>(), result);
+        verify(log).error(contains("Failed to parse error response"), any(), any());
+    }
+
+
+    @Test
+    void testGenericException() throws Exception {
+        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(Map.class)))
+                .thenThrow(new RuntimeException("Unexpected"));
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", Map.of(), null);
+        assertEquals(new HashMap<>(), result);
+        verify(log).error(contains("Unexpected error"), any(), any());
+    }
+
+    @Test
+    void fetchResultUsingPost_withHeaders() throws Exception {
+        Map<String, String> headers = Map.of("Authorization", "token");
+        Map<String, Object> expected = Map.of("key", "value");
+        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(expected);
+        when(mockMapper.writeValueAsString(any())).thenReturn("{}");
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", Map.of(), headers);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void fetchResultUsingPost_debugDisabled() throws Exception {
+        when(log.isDebugEnabled()).thenReturn(false); // skip debug logs
+        Map<String, Object> expected = Map.of("key", "value");
+        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(expected);
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", Map.of(), null);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void fetchResultUsingPost_returnsEmptyMapWhenRestTemplateReturnsNull() throws Exception {
+        when(restTemplate.postForObject(anyString(), any(HttpEntity.class), eq(Map.class)))
+                .thenReturn(null);
+        Map<String, Object> result = service.fetchResultUsingPost("http://example.com", Map.of(), null);
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+}


### PR DESCRIPTION
1. Implemented new method to process the profanity of the text.
2. We will construct the request and call the service registry service which would be calling the content moderation service.
3. These calls would be async ; Kafka listener would be implemented to listen to the topics and process the request.