### PR TITLE
  KB-11210 | BE | DEV | Enhancement in the create answerpost, answerpostreply, update discussion API to check the profanity.

### DIFF
--- a/src/main/java/com/igot/cb/discussion/repository/DiscussionAnswerPostReplyRepository.java
+++ b/src/main/java/com/igot/cb/discussion/repository/DiscussionAnswerPostReplyRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import java.util.Optional;
 
 @Repository
 public interface DiscussionAnswerPostReplyRepository extends JpaRepository<DiscussionAnswerPostReplyEntity, String> {
@@ -13,4 +14,11 @@ public interface DiscussionAnswerPostReplyRepository extends JpaRepository<Discu
     @Transactional
     @Query(value = "UPDATE discussion_answer_post_reply SET profanityresponse = cast(?2 as jsonb), isprofane = ?3 WHERE discussion_id = ?1", nativeQuery = true)
     void updateProfanityFieldsByDiscussionId(String discussionId, String profanityResponseJson, Boolean isProfane);
+
+    @Query(
+            value = "SELECT discussion_id, data, is_active, created_on, updated_on " +
+                    "FROM discussion_answer_post_reply WHERE discussion_id = ?1",
+            nativeQuery = true
+    )
+    Optional<DiscussionAnswerPostReplyEntity> findDiscussionAnswerPostReplyBasedOnDiscussionId(String discussionId);
 }

--- a/src/main/java/com/igot/cb/discussion/repository/DiscussionRepository.java
+++ b/src/main/java/com/igot/cb/discussion/repository/DiscussionRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface DiscussionRepository extends JpaRepository<DiscussionEntity, String>{
 
@@ -15,4 +17,10 @@ public interface DiscussionRepository extends JpaRepository<DiscussionEntity, St
     @Query(value = "UPDATE discussion SET profanityresponse = cast(?2 as jsonb), isprofane = ?3 WHERE discussion_id = ?1", nativeQuery = true)
     void updateProfanityFieldsByDiscussionId(String discussionId, String profanityResponseJson, Boolean isProfane);
 
+    @Query(
+            value = "SELECT discussion_id, data, is_active, created_on, updated_on, up_vote_count, answer_post_count, down_vote_count   " +
+                    "FROM discussion WHERE discussion_id = ?1",
+            nativeQuery = true
+    )
+    Optional<DiscussionEntity> findDiscussionBasedOnDiscussionId(String discussionId);
 }

--- a/src/main/java/com/igot/cb/discussion/service/impl/AnswerPostReplyServiceImpl.java
+++ b/src/main/java/com/igot/cb/discussion/service/impl/AnswerPostReplyServiceImpl.java
@@ -148,6 +148,7 @@ public class AnswerPostReplyServiceImpl implements AnswerPostReplyService {
             jsonNodeEntity.setData(answerPostReplyDataNode);
             jsonNodeEntity.setCreatedOn(currentTime);
             jsonNodeEntity.setUpdatedOn(currentTime);
+            jsonNodeEntity.setIsProfane(false);
             discussionAnswerPostReplyRepository.save(jsonNodeEntity);
 
             ObjectNode jsonNode = objectMapper.createObjectNode();
@@ -377,7 +378,7 @@ public class AnswerPostReplyServiceImpl implements AnswerPostReplyService {
             return response;
         }
 
-        DiscussionAnswerPostReplyEntity discussionAnswerPostReplyEntity = discussionAnswerPostReplyRepository.findById(answerPostReplyData.get(Constants.ANSWER_POST_REPLY_ID).asText()).orElse(null);
+        DiscussionAnswerPostReplyEntity discussionAnswerPostReplyEntity = discussionAnswerPostReplyRepository.findDiscussionAnswerPostReplyBasedOnDiscussionId(answerPostReplyData.get(Constants.ANSWER_POST_REPLY_ID).asText()).orElse(null);
         if (discussionAnswerPostReplyEntity == null || !discussionAnswerPostReplyEntity.getIsActive()) {
             return ProjectUtil.returnErrorMsg(Constants.INVALID_ANSWER_POST_REPLY_ID, HttpStatus.BAD_REQUEST, response, Constants.FAILED);
         }

--- a/src/main/java/com/igot/cb/discussion/service/impl/DiscussionServiceImpl.java
+++ b/src/main/java/com/igot/cb/discussion/service/impl/DiscussionServiceImpl.java
@@ -172,6 +172,7 @@ public class DiscussionServiceImpl implements DiscussionService {
             jsonNodeEntity.setIsActive(true);
             discussionDetailsNode.put(Constants.IS_ACTIVE, true);
             jsonNodeEntity.setData(discussionDetailsNode);
+            jsonNodeEntity.setIsProfane(false);
             long postgresTime = System.currentTimeMillis();
             DiscussionEntity saveJsonEntity = discussionRepository.save(jsonNodeEntity);
             updateMetricsDbOperation(Constants.DISCUSSION_CREATE, Constants.POSTGRES, Constants.INSERT, postgresTime);
@@ -314,7 +315,7 @@ public class DiscussionServiceImpl implements DiscussionService {
             updateMetricsApiCall(Constants.DISCUSSION_UPDATE);
             String discussionId = updateData.get(Constants.DISCUSSION_ID).asText();
             long postgresTime = System.currentTimeMillis();
-            Optional<DiscussionEntity> discussionEntity = discussionRepository.findById(discussionId);
+            Optional<DiscussionEntity> discussionEntity = discussionRepository.findDiscussionBasedOnDiscussionId(discussionId);
             updateMetricsDbOperation(Constants.DISCUSSION_UPDATE, Constants.POSTGRES, Constants.READ, postgresTime);
             if (!discussionEntity.isPresent()) {
                 DiscussionServiceUtil.createErrorResponse(response, "Discussion not found", HttpStatus.NOT_FOUND, Constants.FAILED);
@@ -919,6 +920,7 @@ public class DiscussionServiceImpl implements DiscussionService {
             jsonNodeEntity.setData(answerPostDataNode);
             jsonNodeEntity.setCreatedOn(currentTime);
             jsonNodeEntity.setUpdatedOn(currentTime);
+            jsonNodeEntity.setIsProfane(false);
             long timer = System.currentTimeMillis();
             discussionRepository.save(jsonNodeEntity);
             updateMetricsDbOperation(Constants.DISCUSSION_ANSWER_POST, Constants.POSTGRES, Constants.INSERT, timer);
@@ -1343,7 +1345,7 @@ public class DiscussionServiceImpl implements DiscussionService {
         }
         updateMetricsApiCall(Constants.DISCUSSION_ANSWER_POST);
         long redisTimer = System.currentTimeMillis();
-        DiscussionEntity discussionEntity = discussionRepository.findById(answerPostData.get(Constants.ANSWER_POST_ID).asText()).orElse(null);
+        DiscussionEntity discussionEntity = discussionRepository.findDiscussionBasedOnDiscussionId(answerPostData.get(Constants.ANSWER_POST_ID).asText()).orElse(null);
         updateMetricsDbOperation(Constants.DISCUSSION_ANSWER_POST, Constants.POSTGRES, Constants.READ, redisTimer);
         if (discussionEntity == null || !discussionEntity.getIsActive()) {
             return ProjectUtil.returnErrorMsg(Constants.INVALID_DISCUSSION_ID, HttpStatus.BAD_REQUEST, response, Constants.FAILED);

--- a/src/test/java/com/igot/cb/service/impl/AnswerPostReplyServiceImplTest.java
+++ b/src/test/java/com/igot/cb/service/impl/AnswerPostReplyServiceImplTest.java
@@ -203,7 +203,7 @@ class AnswerPostReplyServiceImplTest {
         entity.setDiscussionId("disc123");
 
         when(accessTokenValidator.verifyUserToken(token)).thenReturn(userId);
-        when(discussionAnswerPostReplyRepository.findById(replyId)).thenReturn(Optional.of(entity));
+        when(discussionAnswerPostReplyRepository.findDiscussionAnswerPostReplyBasedOnDiscussionId(replyId)).thenReturn(Optional.of(entity));
         when(objectMapper.createObjectNode()).thenReturn(new ObjectMapper().createObjectNode());
         when(objectMapper.convertValue(any(), eq(Map.class))).thenReturn(new HashMap<>());
 
@@ -230,7 +230,7 @@ class AnswerPostReplyServiceImplTest {
         entity.setDiscussionId("disc123");
 
         when(accessTokenValidator.verifyUserToken(token)).thenReturn(userId);
-        when(discussionAnswerPostReplyRepository.findById(replyId)).thenReturn(Optional.of(entity));
+        when(discussionAnswerPostReplyRepository.findDiscussionAnswerPostReplyBasedOnDiscussionId(replyId)).thenReturn(Optional.of(entity));
 
         ApiResponse response = service.updateAnswerPostReply(inputNode, token);
 
@@ -747,7 +747,7 @@ class AnswerPostReplyServiceImplTest {
         entity.setData(dbData);
         entity.setDiscussionId("reply123");
 
-        when(discussionAnswerPostReplyRepository.findById(answerPostReplyId)).thenReturn(Optional.of(entity));
+        when(discussionAnswerPostReplyRepository.findDiscussionAnswerPostReplyBasedOnDiscussionId(answerPostReplyId)).thenReturn(Optional.of(entity));
 
         // Force exception in convertValue
         ApiResponse response = service.updateAnswerPostReply(inputData, token);

--- a/src/test/java/com/igot/cb/service/impl/DiscussionServiceImplTest.java
+++ b/src/test/java/com/igot/cb/service/impl/DiscussionServiceImplTest.java
@@ -361,7 +361,7 @@ class DiscussionServiceImplTest {
                 .put("title", "Updated title");
 
         when(accessTokenValidator.verifyUserToken(anyString())).thenReturn("user-123");
-        when(discussionRepository.findById("discussion123")).thenReturn(Optional.of(discussionEntity));
+        when(discussionRepository.findDiscussionBasedOnDiscussionId("discussion123")).thenReturn(Optional.of(discussionEntity));
         when(cbServerProperties.getDiscussionEntity()).thenReturn("discussion_index");
         when(cbServerProperties.getElasticDiscussionJsonPath()).thenReturn("discussion.json");
         when(cbServerProperties.getDiscussionEsDefaultPageSize()).thenReturn(10);
@@ -413,7 +413,7 @@ class DiscussionServiceImplTest {
                 .put(Constants.COMMUNITY_ID, "community-1");
 
         when(accessTokenValidator.verifyUserToken(anyString())).thenReturn("user-123");
-        when(discussionRepository.findById("discussion123")).thenReturn(Optional.of(discussionEntity));
+        when(discussionRepository.findDiscussionBasedOnDiscussionId("discussion123")).thenReturn(Optional.of(discussionEntity));
 
         ApiResponse response = discussionService.updateDiscussion(updateData, "valid_token");
 
@@ -428,7 +428,7 @@ class DiscussionServiceImplTest {
                 .put(Constants.COMMUNITY_ID, "community-2");
 
         when(accessTokenValidator.verifyUserToken(anyString())).thenReturn("user-123");
-        when(discussionRepository.findById("discussion123")).thenReturn(Optional.of(discussionEntity));
+        when(discussionRepository.findDiscussionBasedOnDiscussionId("discussion123")).thenReturn(Optional.of(discussionEntity));
 
         ApiResponse response = discussionService.updateDiscussion(updateData, "valid_token");
 
@@ -443,7 +443,7 @@ class DiscussionServiceImplTest {
                 .put(Constants.COMMUNITY_ID, "community-1");
 
         when(accessTokenValidator.verifyUserToken(anyString())).thenReturn("user-123");
-        when(discussionRepository.findById("discussion123")).thenThrow(new RuntimeException("DB error"));
+        when(discussionRepository.findDiscussionBasedOnDiscussionId("discussion123")).thenThrow(new RuntimeException("DB error"));
 
         ApiResponse response = discussionService.updateDiscussion(updateData, "valid_token");
 
@@ -2320,7 +2320,7 @@ class DiscussionServiceImplTest {
         data.put(Constants.TYPE, "QUESTION"); // Set type to something other than ANSWER_POST
         discussionEntity.setData(data);
 
-        when(discussionRepository.findById("testAnswerPostId")).thenReturn(Optional.of(discussionEntity));
+        when(discussionRepository.findDiscussionBasedOnDiscussionId("testAnswerPostId")).thenReturn(Optional.of(discussionEntity));
 
         // Act
         ApiResponse response = discussionService.updateAnswerPost(answerPostData, token);
@@ -2351,7 +2351,7 @@ class DiscussionServiceImplTest {
         data.put(Constants.STATUS, Constants.SUSPENDED);
         discussionEntity.setData(data);
 
-        when(discussionRepository.findById("answerPost123")).thenReturn(Optional.of(discussionEntity));
+        when(discussionRepository.findDiscussionBasedOnDiscussionId("answerPost123")).thenReturn(Optional.of(discussionEntity));
 
         // Act
         ApiResponse response = discussionService.updateAnswerPost(answerPostData, token);
@@ -2389,7 +2389,7 @@ class DiscussionServiceImplTest {
         data.put(Constants.COMMUNITY_ID, "community123");
         discussionEntity.setData(data);
 
-        when(discussionRepository.findById("answerPost123")).thenReturn(Optional.of(discussionEntity));
+        when(discussionRepository.findDiscussionBasedOnDiscussionId("answerPost123")).thenReturn(Optional.of(discussionEntity));
         when(discussionRepository.save(any(DiscussionEntity.class))).thenReturn(discussionEntity);
 
         when(cbServerProperties.getDiscussionEntity()).thenReturn("discussionEntity");
@@ -2434,7 +2434,7 @@ class DiscussionServiceImplTest {
         discussionEntity.setData(data);
 
         when(accessTokenValidator.verifyUserToken(token)).thenReturn(userId);
-        when(discussionRepository.findById(answerId)).thenReturn(Optional.of(discussionEntity));
+        when(discussionRepository.findDiscussionBasedOnDiscussionId(answerId)).thenReturn(Optional.of(discussionEntity));
         when(discussionRepository.save(any(DiscussionEntity.class))).thenReturn(discussionEntity);
         when(cbServerProperties.getDiscussionEntity()).thenReturn("discussionEntity");
         when(cbServerProperties.getElasticDiscussionJsonPath()).thenReturn("elasticPath");
@@ -2472,7 +2472,7 @@ class DiscussionServiceImplTest {
 
         // Mocks
         when(accessTokenValidator.verifyUserToken(token)).thenReturn("user123");
-        when(discussionRepository.findById("answer-post-123")).thenReturn(Optional.of(mockEntity));
+        when(discussionRepository.findDiscussionBasedOnDiscussionId("answer-post-123")).thenReturn(Optional.of(mockEntity));
         doThrow(new RuntimeException("Simulated DB failure")).when(discussionRepository).save(any());
 
         // Act


### PR DESCRIPTION
1. Added a select query to select specific fields which would be needed while updating the post .answerPost,answerPostReply -skipping profanity related fields.
2. Setting the profanity flag to false by default while post creation.
3. Test cases updated.