### PR TITLE
KB-11292 | BE | DEV | Enhancements in the APIs to check the profanity

### DIFF
--- a/src/main/java/com/igot/cb/discussion/service/impl/AnswerPostReplyServiceImpl.java
+++ b/src/main/java/com/igot/cb/discussion/service/impl/AnswerPostReplyServiceImpl.java
@@ -253,6 +253,7 @@ public class AnswerPostReplyServiceImpl implements AnswerPostReplyService {
         ObjectNode jsonNode = objectMapper.createObjectNode();
         jsonNode.setAll((ObjectNode) savedEntity.getData());
         Map<String, Object> map = objectMapper.convertValue(jsonNode, Map.class);
+        map.put(IS_PROFANE,false);
         esUtilService.updateDocument(cbServerProperties.getDiscussionEntity(), discussionEntity.getDiscussionId(), map, cbServerProperties.getElasticDiscussionJsonPath());
         cacheService.putCache(Constants.DISCUSSION_CACHE_PREFIX + discussionEntity.getDiscussionId(), jsonNode);
     }

--- a/src/main/java/com/igot/cb/discussion/service/impl/DiscussionServiceImpl.java
+++ b/src/main/java/com/igot/cb/discussion/service/impl/DiscussionServiceImpl.java
@@ -1046,7 +1046,7 @@ public class DiscussionServiceImpl implements DiscussionService {
         ObjectNode jsonNode = objectMapper.createObjectNode();
         jsonNode.setAll((ObjectNode) savedEntity.getData());
         Map<String, Object> map = objectMapper.convertValue(jsonNode, Map.class);
-
+        map.put(IS_PROFANE,false);
         esUtilService.updateDocument(cbServerProperties.getDiscussionEntity(), discussionEntity.getDiscussionId(), map, cbServerProperties.getElasticDiscussionJsonPath());
         cacheService.putCache(Constants.DISCUSSION_CACHE_PREFIX + discussionEntity.getDiscussionId(), jsonNode);
     }

--- a/src/main/java/com/igot/cb/profanity/consumer/LanguageDetectionConsumer.java
+++ b/src/main/java/com/igot/cb/profanity/consumer/LanguageDetectionConsumer.java
@@ -51,7 +51,7 @@ public class LanguageDetectionConsumer {
                         cbServerProperties.getContentModerationServiceUrl() + "/" + cbServerProperties.getContentModerationLanguageDetectApiPath(), langDetectBody,
                         langDetectHeaders
                 );
-                String detectedLanguage = "";
+                 String detectedLanguage = "";
                 if (langDetectResponse != null && langDetectResponse.containsKey(Constants.DETECTED_LANGUAGE)) {
                     Object lang = langDetectResponse.get(Constants.DETECTED_LANGUAGE);
                     if (lang != null) {

--- a/src/main/java/com/igot/cb/profanity/consumer/LanguageDetectionConsumer.java
+++ b/src/main/java/com/igot/cb/profanity/consumer/LanguageDetectionConsumer.java
@@ -51,7 +51,7 @@ public class LanguageDetectionConsumer {
                         cbServerProperties.getContentModerationServiceUrl() + "/" + cbServerProperties.getContentModerationLanguageDetectApiPath(), langDetectBody,
                         langDetectHeaders
                 );
-                 String detectedLanguage = "";
+                String detectedLanguage = "";
                 if (langDetectResponse != null && langDetectResponse.containsKey(Constants.DETECTED_LANGUAGE)) {
                     Object lang = langDetectResponse.get(Constants.DETECTED_LANGUAGE);
                     if (lang != null) {

--- a/src/main/java/com/igot/cb/profanity/consumer/ProfanityConsumer.java
+++ b/src/main/java/com/igot/cb/profanity/consumer/ProfanityConsumer.java
@@ -133,6 +133,9 @@ public class ProfanityConsumer {
                             IS_PROFANE, true
                     );
                     notificationTriggerService.triggerNotification(Constants.PROFANITY_CHECK, ALERT, Collections.singletonList(userId), TITLE, firstName, notificationData);
+                    discussionService.deleteCacheByCommunity(Constants.DISCUSSION_CACHE_PREFIX + data.get(Constants.COMMUNITY_ID).asText());
+                    discussionService.deleteCacheByCommunity(Constants.DISCUSSION_POSTS_BY_USER + data.get(Constants.COMMUNITY_ID).asText() + Constants.UNDER_SCORE + userId);
+                    discussionService.updateCacheForFirstFivePages(data.get(Constants.COMMUNITY_ID).asText(), false);
                 }
             }
         } else {

--- a/src/test/java/com/igot/cb/profanity/consumer/LanguageDetectionConsumerTest.java
+++ b/src/test/java/com/igot/cb/profanity/consumer/LanguageDetectionConsumerTest.java
@@ -1,0 +1,154 @@
+package com.igot.cb.profanity.consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.igot.cb.pores.util.CbServerProperties;
+import com.igot.cb.pores.util.Constants;
+import com.igot.cb.profanity.IProfanityCheckService;
+import com.igot.cb.transactional.service.RequestHandlerServiceImpl;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+class LanguageDetectionConsumerTest {
+
+    @InjectMocks
+    private LanguageDetectionConsumer consumer;
+
+    @Mock
+    private ObjectMapper mapper;
+    @Mock
+    private CbServerProperties cbServerProperties;
+    @Mock
+    private RequestHandlerServiceImpl requestHandlerService;
+    @Mock
+    private IProfanityCheckService profanityCheckService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testCheckTextLanguage_success() throws Exception {
+        String id = "discussion123";
+        String text = "Hello world";
+        String detectedLanguage = "en";
+        String json = "{\"discussionId\":\"" + id + "\",\"text\":\"" + text + "\"}";
+
+        ObjectNode node = mock(ObjectNode.class);
+        JsonNode idNode = mock(JsonNode.class);
+        when(idNode.asText()).thenReturn(id);
+        when(node.get(Constants.DISCUSSION_ID)).thenReturn(idNode);
+        JsonNode textNode = mock(JsonNode.class);
+        when(textNode.asText()).thenReturn(text);
+        when(node.get(Constants.TEXT)).thenReturn(textNode);
+        when(mapper.readTree(json)).thenReturn(node);
+
+        Map<String, Object> langDetectResponse = new HashMap<>();
+        langDetectResponse.put(Constants.DETECTED_LANGUAGE, detectedLanguage);
+
+        when(cbServerProperties.getCbDiscussionApiKey()).thenReturn("api-key");
+        when(cbServerProperties.getContentModerationServiceUrl()).thenReturn("http://service");
+        when(cbServerProperties.getContentModerationLanguageDetectApiPath()).thenReturn("detect");
+        when(requestHandlerService.fetchResultUsingPost(anyString(), anyMap(), anyMap()))
+                .thenReturn(langDetectResponse);
+
+        ConsumerRecord<String, String> record = new ConsumerRecord<>("topic", 0, 0L, null, json);
+
+        consumer.checkTextLanguage(record);
+
+        verify(node).put(Constants.LANGUAGE, detectedLanguage);
+        verify(profanityCheckService).processProfanityCheck(id, node);
+    }
+
+    @Test
+    void testCheckTextLanguage_noDetectedLanguageKey() throws Exception {
+        String id = "discussion123";
+        String text = "Hello world";
+        String json = "{\"discussionId\":\"" + id + "\",\"text\":\"" + text + "\"}";
+
+        ObjectNode node = mock(ObjectNode.class);
+        JsonNode idNode = mock(JsonNode.class);
+        when(idNode.asText()).thenReturn(id);
+        when(node.get(Constants.DISCUSSION_ID)).thenReturn(idNode);
+        JsonNode textNode = mock(JsonNode.class);
+        when(textNode.asText()).thenReturn(text);
+        when(node.get(Constants.TEXT)).thenReturn(textNode);
+        when(mapper.readTree(json)).thenReturn(node);
+
+        Map<String, Object> langDetectResponse = new HashMap<>();
+        // No DETECTED_LANGUAGE key
+
+        when(cbServerProperties.getCbDiscussionApiKey()).thenReturn("api-key");
+        when(cbServerProperties.getContentModerationServiceUrl()).thenReturn("http://service");
+        when(cbServerProperties.getContentModerationLanguageDetectApiPath()).thenReturn("detect");
+        when(requestHandlerService.fetchResultUsingPost(anyString(), anyMap(), anyMap()))
+                .thenReturn(langDetectResponse);
+
+        ConsumerRecord<String, String> record = new ConsumerRecord<>("topic", 0, 0L, null, json);
+
+        consumer.checkTextLanguage(record);
+
+        verify(node, never()).put(eq(Constants.LANGUAGE), anyString());
+        verifyNoInteractions(profanityCheckService);
+    }
+
+    @Test
+    void testCheckTextLanguage_detectedLanguageNull() throws Exception {
+        String id = "discussion123";
+        String text = "Hello world";
+        String json = "{\"discussionId\":\"" + id + "\",\"text\":\"" + text + "\"}";
+
+        ObjectNode node = mock(ObjectNode.class);
+        JsonNode idNode = mock(JsonNode.class);
+        when(idNode.asText()).thenReturn(id);
+        when(node.get(Constants.DISCUSSION_ID)).thenReturn(idNode);
+        JsonNode textNode = mock(JsonNode.class);
+        when(textNode.asText()).thenReturn(text);
+        when(node.get(Constants.TEXT)).thenReturn(textNode);
+        when(mapper.readTree(json)).thenReturn(node);
+
+        Map<String, Object> langDetectResponse = new HashMap<>();
+        langDetectResponse.put(Constants.DETECTED_LANGUAGE, null);
+
+        when(cbServerProperties.getCbDiscussionApiKey()).thenReturn("api-key");
+        when(cbServerProperties.getContentModerationServiceUrl()).thenReturn("http://service");
+        when(cbServerProperties.getContentModerationLanguageDetectApiPath()).thenReturn("detect");
+        when(requestHandlerService.fetchResultUsingPost(anyString(), anyMap(), anyMap()))
+                .thenReturn(langDetectResponse);
+
+        ConsumerRecord<String, String> record = new ConsumerRecord<>("topic", 0, 0L, null, json);
+
+        consumer.checkTextLanguage(record);
+
+        verify(node, never()).put(eq(Constants.LANGUAGE), anyString());
+        verifyNoInteractions(profanityCheckService);
+    }
+
+    @Test
+    void testCheckTextLanguage_emptyValue() {
+        ConsumerRecord<String, String> record = new ConsumerRecord<>("topic", 0, 0L, null, "");
+        consumer.checkTextLanguage(record);
+        verifyNoInteractions(mapper, profanityCheckService, requestHandlerService);
+    }
+
+    @Test
+    void testCheckTextLanguage_invalidJson() throws Exception {
+        String invalidJson = "{invalid";
+        when(mapper.readTree(invalidJson)).thenThrow(new JsonProcessingException("error") {
+        });
+        ConsumerRecord<String, String> record = new ConsumerRecord<>("topic", 0, 0L, null, invalidJson);
+        consumer.checkTextLanguage(record);
+        verify(mapper).readTree(invalidJson);
+        verifyNoInteractions(profanityCheckService, requestHandlerService);
+    }
+}

--- a/src/test/java/com/igot/cb/profanity/consumer/ProfanityConsumerTest.java
+++ b/src/test/java/com/igot/cb/profanity/consumer/ProfanityConsumerTest.java
@@ -10,6 +10,7 @@ import com.igot.cb.discussion.entity.DiscussionAnswerPostReplyEntity;
 import com.igot.cb.discussion.entity.DiscussionEntity;
 import com.igot.cb.discussion.repository.DiscussionAnswerPostReplyRepository;
 import com.igot.cb.discussion.repository.DiscussionRepository;
+import com.igot.cb.discussion.service.DiscussionService;
 import com.igot.cb.notificationUtill.HelperMethodService;
 import com.igot.cb.notificationUtill.NotificationTriggerService;
 import com.igot.cb.pores.elasticsearch.service.EsUtilService;
@@ -67,6 +68,9 @@ class ProfanityConsumerTest {
 
     @Mock
     private NotificationTriggerService notificationTriggerService;
+
+    @Mock
+    private DiscussionService discussionService;
 
     private static final String BASE_JSON_TEMPLATE = """
             {
@@ -338,6 +342,9 @@ class ProfanityConsumerTest {
         when(cbServerProperties.getElasticDiscussionJsonPath()).thenReturn("jsonPath");
         when(mapper.convertValue(eq(data), any(TypeReference.class))).thenReturn(new HashMap<>());
         when(helperMethodService.fetchUserFirstName("user123")).thenReturn("TestUser");
+        var discussionServiceField = ProfanityConsumer.class.getDeclaredField("discussionService");
+        discussionServiceField.setAccessible(true);
+        discussionServiceField.set(profanityConsumer, discussionService);
         var method = ProfanityConsumer.class.getDeclaredMethod("syncProfaneDetailsToESForDiscussion", String.class, boolean.class, String.class);
         method.setAccessible(true);
         var objectMapperField = ProfanityConsumer.class.getDeclaredField("objectMapper");

--- a/src/test/java/com/igot/cb/transactional/cassandrautils/CassandraConnectionManagerImplTest.java
+++ b/src/test/java/com/igot/cb/transactional/cassandrautils/CassandraConnectionManagerImplTest.java
@@ -101,14 +101,17 @@ class CassandraConnectionManagerImplTest {
 
     @Test
     void test_getSession_connectionException() {
-        try (MockedStatic<PropertiesCache> staticMock = mockStatic(PropertiesCache.class)) {
+        try (
+                MockedStatic<PropertiesCache> staticMock = mockStatic(PropertiesCache.class);
+                MockedStatic<CqlSession> sessionMock = mockStatic(CqlSession.class)
+        ) {
             staticMock.when(PropertiesCache::getInstance).thenReturn(propertiesCache);
             when(propertiesCache.getProperty(Constants.CASSANDRA_CONFIG_HOST)).thenReturn("localhost");
             when(propertiesCache.getProperty(Constants.CORE_CONNECTIONS_PER_HOST_FOR_LOCAL)).thenReturn("1");
             when(propertiesCache.getProperty(Constants.CORE_CONNECTIONS_PER_HOST_FOR_REMOTE)).thenReturn("1");
             when(propertiesCache.getProperty(Constants.HEARTBEAT_INTERVAL)).thenReturn("30");
             when(propertiesCache.readProperty(Constants.SUNBIRD_CASSANDRA_CONSISTENCY_LEVEL)).thenReturn("LOCAL_QUORUM");
-
+            sessionMock.when(CqlSession::builder).thenThrow(new RuntimeException("Connection failed"));
             assertThrows(CustomException.class, CassandraConnectionManagerImpl::new);
         }
     }


### PR DESCRIPTION
1. While updating to the elastic search we need to make sure the parent post detail  for both post and answerpostreply isprofane flag should be updated .
2. Will be deleting the community feed cache for user is the content is found profane.
3. Added the test cases for language detection consumer, cassandra service since build was failing, and profanity consumer.