### PR TITLE
 KB-11292 | BE | DEV | Enhancements in the APIs to check the profanity

### DIFF
--- a/src/main/java/com/igot/cb/profanity/consumer/LanguageDetectionConsumer.java
+++ b/src/main/java/com/igot/cb/profanity/consumer/LanguageDetectionConsumer.java
@@ -40,7 +40,7 @@ public class LanguageDetectionConsumer {
             try {
                 ObjectNode discussionDetailsNode = (ObjectNode) mapper.readTree(textData.value());
                 String id = discussionDetailsNode.get(Constants.DISCUSSION_ID).asText();
-                String text = discussionDetailsNode.get(Constants.TEXT).asText();
+                String text = discussionDetailsNode.get(Constants.DESCRIPTION).asText();
                 Map<String, Object> langDetectBody = new HashMap<>();
                 langDetectBody.put(Constants.TEXT, text);
                 Map<String, String> langDetectHeaders = new HashMap<>();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -95,7 +95,7 @@ notification.api.url=http://cb-notification-wrapper-service:8081/notifications/c
 cb.service.registry.base.url=http://cb-service-registry:8096
 cb.registry.textmoderation.api.path=serviceregistry/v1/callExternalApi
 cb.discussion.api.key=bearer apiKey
-content.moderation.language.detect.api.path=v1/content/language/detect
+content.moderation.language.detect.api.path=/api/v1/language/detect
 content.moderation.service.url=http://content-moderation-service:8000
 
 kafka.topic.process.check.content.profanity=dev.process.check.content.profanity

--- a/src/test/java/com/igot/cb/profanity/consumer/LanguageDetectionConsumerTest.java
+++ b/src/test/java/com/igot/cb/profanity/consumer/LanguageDetectionConsumerTest.java
@@ -50,7 +50,7 @@ class LanguageDetectionConsumerTest {
         when(node.get(Constants.DISCUSSION_ID)).thenReturn(idNode);
         JsonNode textNode = mock(JsonNode.class);
         when(textNode.asText()).thenReturn(text);
-        when(node.get(Constants.TEXT)).thenReturn(textNode);
+        when(node.get(Constants.DESCRIPTION)).thenReturn(textNode);
         when(mapper.readTree(json)).thenReturn(node);
 
         Map<String, Object> langDetectResponse = new HashMap<>();
@@ -82,7 +82,7 @@ class LanguageDetectionConsumerTest {
         when(node.get(Constants.DISCUSSION_ID)).thenReturn(idNode);
         JsonNode textNode = mock(JsonNode.class);
         when(textNode.asText()).thenReturn(text);
-        when(node.get(Constants.TEXT)).thenReturn(textNode);
+        when(node.get(Constants.DESCRIPTION)).thenReturn(textNode);
         when(mapper.readTree(json)).thenReturn(node);
 
         Map<String, Object> langDetectResponse = new HashMap<>();
@@ -114,7 +114,7 @@ class LanguageDetectionConsumerTest {
         when(node.get(Constants.DISCUSSION_ID)).thenReturn(idNode);
         JsonNode textNode = mock(JsonNode.class);
         when(textNode.asText()).thenReturn(text);
-        when(node.get(Constants.TEXT)).thenReturn(textNode);
+        when(node.get(Constants.DESCRIPTION)).thenReturn(textNode);
         when(mapper.readTree(json)).thenReturn(node);
 
         Map<String, Object> langDetectResponse = new HashMap<>();


### PR DESCRIPTION
1. Changed the attribute name in the kafka listener class - while passing from service layer we are passing as DESCRIPTION.
2. Fixed the test cases.
3. Added the proper content moderation API in the application.properties