### PR TITLE
KB-11210 | BE | DEV | Enhancement in the create answerpost, answerpostreply, update discussion API to check the profanity.

### DIFF
--- a/src/main/java/com/igot/cb/discussion/entity/DiscussionAnswerPostReplyEntity.java
+++ b/src/main/java/com/igot/cb/discussion/entity/DiscussionAnswerPostReplyEntity.java
@@ -40,4 +40,7 @@ public class DiscussionAnswerPostReplyEntity {
 
     @Column(name = "isprofane")
     private Boolean isProfane;
+
+    @Column(name = "profanitycheckstatus")
+    private String profanityCheckStatus;
 }

--- a/src/main/java/com/igot/cb/discussion/entity/DiscussionEntity.java
+++ b/src/main/java/com/igot/cb/discussion/entity/DiscussionEntity.java
@@ -41,6 +41,9 @@ public class DiscussionEntity {
     @Column(name = "isprofane")
     private Boolean isProfane;
 
+    @Column(name = "profanitycheckstatus")
+    private String profanityCheckStatus;
+
     public DiscussionEntity(String discussionId, JsonNode data, Boolean isActive, Timestamp createdOn, Timestamp updatedOn) {
         this.discussionId = discussionId;
         this.data = data;

--- a/src/main/java/com/igot/cb/discussion/repository/DiscussionAnswerPostReplyRepository.java
+++ b/src/main/java/com/igot/cb/discussion/repository/DiscussionAnswerPostReplyRepository.java
@@ -11,6 +11,11 @@ import org.springframework.stereotype.Repository;
 public interface DiscussionAnswerPostReplyRepository extends JpaRepository<DiscussionAnswerPostReplyEntity, String> {
     @Modifying
     @Transactional
-    @Query(value = "UPDATE discussion_answer_post_reply SET profanityresponse = cast(?2 as jsonb), isprofane = ?3 WHERE discussion_id = ?1", nativeQuery = true)
-    void updateProfanityFieldsByDiscussionId(String discussionId, String profanityResponseJson, Boolean isProfane);
+    @Query(value = "UPDATE discussion_answer_post_reply SET profanityresponse = cast(?2 as jsonb), isprofane = ?3, profanitycheckstatus = ?4 WHERE discussion_id = ?1", nativeQuery = true)
+    void updateProfanityFieldsByDiscussionId(String discussionId, String profanityResponseJson, Boolean isProfane, String profanityCheckStatus);
+
+    @Modifying
+    @Transactional
+    @Query(value = "UPDATE discussion_answer_post_reply SET profanitycheckstatus = ?2, isprofane = ?3 WHERE discussion_id = ?1", nativeQuery = true)
+    void updateProfanityCheckStatusByDiscussionId(String discussionId, String profanityCheckStatus, Boolean isProfane);
 }

--- a/src/main/java/com/igot/cb/discussion/repository/DiscussionRepository.java
+++ b/src/main/java/com/igot/cb/discussion/repository/DiscussionRepository.java
@@ -12,7 +12,11 @@ public interface DiscussionRepository extends JpaRepository<DiscussionEntity, St
 
     @Modifying
     @Transactional
-    @Query(value = "UPDATE discussion SET profanityresponse = cast(?2 as jsonb), isprofane = ?3 WHERE discussion_id = ?1", nativeQuery = true)
-    void updateProfanityFieldsByDiscussionId(String discussionId, String profanityResponseJson, Boolean isProfane);
+    @Query(value = "UPDATE discussion SET profanityresponse = cast(?2 as jsonb), isprofane = ?3, profanitycheckstatus = ?4 WHERE discussion_id = ?1", nativeQuery = true)
+    void updateProfanityFieldsByDiscussionId(String discussionId, String profanityResponseJson, Boolean isProfane, String profanityCheckStatus);
 
+    @Modifying
+    @Transactional
+    @Query(value = "UPDATE discussion SET profanitycheckstatus = ?2, isprofane = ?3 WHERE discussion_id = ?1", nativeQuery = true)
+    void updateProfanityCheckStatusByDiscussionId(String discussionId, String profanityCheckStatus, Boolean isProfane);
 }

--- a/src/main/java/com/igot/cb/pores/util/Constants.java
+++ b/src/main/java/com/igot/cb/pores/util/Constants.java
@@ -288,6 +288,10 @@ public class Constants {
     public static final String IS_PROFANE = "isProfane";
     public static final String PROFANITY_RESPONSE = "profanityresponse";
     public static final String DETECTED_LANGUAGE = "detected_language";
+    public static final String LANGUAGE_NOT_DETECTED = "languageNotDetected";
+    public static final String PROFANITY_CHECK_CALL_FAILED = "profanityCheckCallFailed";
+    public static final String PROFANITY_CHECK_UPDATE_FAILED = "profanityCheckUpdateFailed";
+    public static final String PROFANITY_CHECK_PASSED = "profanityCheckPassed";
 
     private Constants() {
     }

--- a/src/main/java/com/igot/cb/profanity/consumer/ProfanityConsumer.java
+++ b/src/main/java/com/igot/cb/profanity/consumer/ProfanityConsumer.java
@@ -99,6 +99,11 @@ public class ProfanityConsumer {
                         updateProfanityFieldsAndSync(type, discussionId, profanityResponseJson, isProfane, parentDiscussionId, parentAnswerPostId);
                     } catch (Exception ex) {
                         log.error("Failed to update profanity fields for Discussion: {}", discussionId, ex);
+                        if (Constants.QUESTION.equalsIgnoreCase(type) || Constants.ANSWER_POST.equalsIgnoreCase(type)) {
+                            discussionRepository.updateProfanityCheckStatusByDiscussionId(discussionId, Constants.PROFANITY_CHECK_UPDATE_FAILED, false);
+                        } else if (Constants.ANSWER_POST_REPLY.equalsIgnoreCase(type)) {
+                            discussionAnswerPostReplyRepository.updateProfanityCheckStatusByDiscussionId(discussionId, Constants.PROFANITY_CHECK_UPDATE_FAILED, false);
+                        }
                     }
                 });
             } catch (JsonProcessingException e) {
@@ -190,11 +195,11 @@ public class ProfanityConsumer {
      */
     private void updateProfanityFieldsAndSync(String type, String discussionId, String profanityResponseJson, boolean isProfane, String parentDiscussionId, String parentAnswerPostId) {
         if (Constants.QUESTION.equalsIgnoreCase(type) || Constants.ANSWER_POST.equalsIgnoreCase(type)) {
-            discussionRepository.updateProfanityFieldsByDiscussionId(discussionId, profanityResponseJson, isProfane);
+            discussionRepository.updateProfanityFieldsByDiscussionId(discussionId, profanityResponseJson, isProfane, Constants.PROFANITY_CHECK_PASSED);
             log.info("Successfully updated profanity fields for Discussion: {}", discussionId);
             syncProfaneDetailsToESForDiscussion(discussionId, isProfane, type, parentDiscussionId);
         } else if (Constants.ANSWER_POST_REPLY.equalsIgnoreCase(type)) {
-            discussionAnswerPostReplyRepository.updateProfanityFieldsByDiscussionId(discussionId, profanityResponseJson, isProfane);
+            discussionAnswerPostReplyRepository.updateProfanityFieldsByDiscussionId(discussionId, profanityResponseJson, isProfane, Constants.PROFANITY_CHECK_PASSED);
             log.info("Successfully updated profanity fields for Answer Post Reply: {}", discussionId);
             syncProfaneDetailsToESForAnswerPost(discussionId, isProfane, parentDiscussionId, parentAnswerPostId);
         }

--- a/src/test/java/com/igot/cb/discussion/entity/DiscussionAnswerPostReplyEntityTest.java
+++ b/src/test/java/com/igot/cb/discussion/entity/DiscussionAnswerPostReplyEntityTest.java
@@ -56,7 +56,8 @@ class DiscussionAnswerPostReplyEntityTest {
                 createdOn,
                 updatedOn,
                 profanityresponse,
-                true
+                true,
+                "profanity_check_status"
         );
 
         assertEquals("d456", entity.getDiscussionId());

--- a/src/test/java/com/igot/cb/discussion/entity/DiscussionEntityTest.java
+++ b/src/test/java/com/igot/cb/discussion/entity/DiscussionEntityTest.java
@@ -56,7 +56,8 @@ class DiscussionEntityTest {
                 createdOn,
                 updatedOn,
                 profanityResponse,
-                true
+                true,
+                "profanity_check_status"
         );
 
         assertEquals("d456", entity.getDiscussionId());

--- a/src/test/java/com/igot/cb/profanity/consumer/ProfanityConsumerTest.java
+++ b/src/test/java/com/igot/cb/profanity/consumer/ProfanityConsumerTest.java
@@ -118,7 +118,7 @@ class ProfanityConsumerTest {
         when(mockNode.toString()).thenReturn(kafkaValue);
         profanityConsumer.checkTextContentIsProfane(consumerRecord);
         await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
-            verify(discussionRepository).updateProfanityFieldsByDiscussionId("post123", kafkaValue, true);
+            verify(discussionRepository).updateProfanityFieldsByDiscussionId("post123", kafkaValue, true,Constants.PROFANITY_CHECK_PASSED);
         });
     }
 
@@ -132,7 +132,7 @@ class ProfanityConsumerTest {
         when(mockNode.toString()).thenReturn(kafkaValue);
         profanityConsumer.checkTextContentIsProfane(consumerRecord);
         await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
-            verify(discussionRepository).updateProfanityFieldsByDiscussionId("post456", kafkaValue, false);
+            verify(discussionRepository).updateProfanityFieldsByDiscussionId("post456", kafkaValue, false,Constants.PROFANITY_CHECK_PASSED);
         });
     }
 
@@ -147,7 +147,7 @@ class ProfanityConsumerTest {
         profanityConsumer.checkTextContentIsProfane(consumerRecord);
         await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
             verify(discussionAnswerPostReplyRepository)
-                    .updateProfanityFieldsByDiscussionId("reply123", kafkaValue, true);
+                    .updateProfanityFieldsByDiscussionId("reply123", kafkaValue, true,Constants.PROFANITY_CHECK_PASSED);
         });
     }
 


### PR DESCRIPTION

1.Add new attribute in postgres - profanitycheckstatus for tracking the status  - languageNotDetected,profanityCheckCallFailed,profanityCheckUpdateFailed,profanityCheckPassed. 2.Updated the test cases.