### PR TITLE
KB-11210 | BE | DEV | Enhancement in the create answerpost, answerpostreply, update discussion API to check the profanity.

### DIFF
--- a/src/main/java/com/igot/cb/discussion/service/impl/AnswerPostReplyServiceImpl.java
+++ b/src/main/java/com/igot/cb/discussion/service/impl/AnswerPostReplyServiceImpl.java
@@ -253,7 +253,7 @@ public class AnswerPostReplyServiceImpl implements AnswerPostReplyService {
         ObjectNode jsonNode = objectMapper.createObjectNode();
         jsonNode.setAll((ObjectNode) savedEntity.getData());
         Map<String, Object> map = objectMapper.convertValue(jsonNode, Map.class);
-        map.put(IS_PROFANE,false);
+        map.put(IS_PROFANE, Boolean.TRUE.equals(discussionEntity.getIsProfane()));
         esUtilService.updateDocument(cbServerProperties.getDiscussionEntity(), discussionEntity.getDiscussionId(), map, cbServerProperties.getElasticDiscussionJsonPath());
         cacheService.putCache(Constants.DISCUSSION_CACHE_PREFIX + discussionEntity.getDiscussionId(), jsonNode);
     }

--- a/src/main/java/com/igot/cb/discussion/service/impl/DiscussionServiceImpl.java
+++ b/src/main/java/com/igot/cb/discussion/service/impl/DiscussionServiceImpl.java
@@ -1045,7 +1045,7 @@ public class DiscussionServiceImpl implements DiscussionService {
         ObjectNode jsonNode = objectMapper.createObjectNode();
         jsonNode.setAll((ObjectNode) savedEntity.getData());
         Map<String, Object> map = objectMapper.convertValue(jsonNode, Map.class);
-        map.put(IS_PROFANE,false);
+        map.put(IS_PROFANE, Boolean.TRUE.equals(discussionEntity.getIsProfane()));
         esUtilService.updateDocument(cbServerProperties.getDiscussionEntity(), discussionEntity.getDiscussionId(), map, cbServerProperties.getElasticDiscussionJsonPath());
         cacheService.putCache(Constants.DISCUSSION_CACHE_PREFIX + discussionEntity.getDiscussionId(), jsonNode);
     }

--- a/src/main/java/com/igot/cb/profanity/consumer/ProfanityConsumer.java
+++ b/src/main/java/com/igot/cb/profanity/consumer/ProfanityConsumer.java
@@ -163,7 +163,10 @@ public class ProfanityConsumer {
                     log.info("Profanity detected in answer post reply: {}", discussionId);
                     handleProfanityForAnswerPostReplyCreation(parentDiscussionId, parentAnswerPostId, discussionAnswerPostReply, data);
                     Optional<DiscussionEntity> discussionEntity = discussionRepository.findById(discussionId);
-                    discussionEntity.ifPresent(discussionDbData -> answerPostReplyService.updateAnswerPostReplyToAnswerPost(discussionDbData, discussionId, DECREMENT));
+                    discussionEntity.ifPresent(discussionDbData -> {
+                        discussionDbData.setIsProfane(true);
+                        answerPostReplyService.updateAnswerPostReplyToAnswerPost(discussionDbData, discussionId, DECREMENT);
+                    });
                 }
             }
         } else {
@@ -243,6 +246,7 @@ public class ProfanityConsumer {
                             parentDiscussionId,
                             data.get(Constants.COMMUNITY_ID).asText(),
                             Constants.ANSWER_POST)));
+            discussionDbData.setIsProfane(true);
             discussionService.updateAnswerPostToDiscussion(discussionDbData, data.get(Constants.DISCUSSION_ID).asText(), DECREMENT);
         }
     }


### PR DESCRIPTION
1. updateAnswerPostReplyToAnswerPost. updateAnswerPostToDiscussion are generic method to update the parent discussion once the answerpost and answerpostreply are created.
2. isProfane was hardcoded to false ; now it would conditionaly checked - if the entity object has the data it would be appended or it would be false by default.