### PR TITLE
KB-11210 | BE | DEV | Enhancement in the create answerpost, answerpostreply, update discussion API to check the profanity.

### DIFF
--- a/src/main/java/com/igot/cb/pores/util/Constants.java
+++ b/src/main/java/com/igot/cb/pores/util/Constants.java
@@ -293,6 +293,7 @@ public class Constants {
     public static final String PROFANITY_CHECK_UPDATE_FAILED = "profanityCheckUpdateFailed";
     public static final String PROFANITY_CHECK_PASSED = "profanityCheckPassed";
     public static final String LANGUAGE_DETECTION_CALL_FAILED = "languageDetectionCallFailed";
+    public static final String FAILED_LOWERCASE = "failed";
 
     private Constants() {
     }


### PR DESCRIPTION

1.  Handling the profanity check failed.
2. Kafka event would be received when the profanity check is failed will be updating the status to the db.