### PR TITLE
KB-11494 | BE | DEV |Setting the default langauge to english for content moderation.

### DIFF
--- a/src/main/java/com/igot/cb/pores/util/CbServerProperties.java
+++ b/src/main/java/com/igot/cb/pores/util/CbServerProperties.java
@@ -115,4 +115,7 @@ public class CbServerProperties {
   @Value("${content.moderation.service.url}")
   private String contentModerationServiceUrl;
 
+  @Value("${enable.english.language.by.default}")
+  private boolean enableEnglishLanguageByDefault;
+
 }

--- a/src/main/java/com/igot/cb/pores/util/Constants.java
+++ b/src/main/java/com/igot/cb/pores/util/Constants.java
@@ -281,7 +281,6 @@ public class Constants {
     public static final String REQUEST_BODY = "requestBody";
     public static final String SERVICE_CODE = "serviceCode";
     public static final String PROFANITY_CHECK = "PROFANITY_CHECK";
-    public static final String LANGUAGE_CODE = "languageCode";
     public static final String REQUEST_DATA = "request_data";
     public static final String RESPONSE_DATA = "response_data";
     public static final String RESPONSE_DATA_PATH = "responseData";
@@ -294,7 +293,7 @@ public class Constants {
     public static final String PROFANITY_CHECK_PASSED = "profanityCheckPassed";
     public static final String LANGUAGE_DETECTION_CALL_FAILED = "languageDetectionCallFailed";
     public static final String FAILED_LOWERCASE = "failed";
-
+    public static final String ENGLISH_LANGUAGE_CODE = "en";
     private Constants() {
     }
 }

--- a/src/main/java/com/igot/cb/profanity/consumer/LanguageDetectionConsumer.java
+++ b/src/main/java/com/igot/cb/profanity/consumer/LanguageDetectionConsumer.java
@@ -49,19 +49,9 @@ public class LanguageDetectionConsumer {
                 ObjectNode discussionDetailsNode = (ObjectNode) mapper.readTree(textData.value());
                 String id = discussionDetailsNode.get(Constants.DISCUSSION_ID).asText();
                 String text = discussionDetailsNode.get(Constants.DESCRIPTION).asText();
-                Map<String, Object> langDetectResponse = callLanguageDetectionService(discussionDetailsNode,id,text);
                 String detectedLanguage = "";
-                if (MapUtils.isNotEmpty(langDetectResponse)) {
-                    Object lang = langDetectResponse.get(Constants.DETECTED_LANGUAGE);
-                    if (lang != null) {
-                        detectedLanguage = lang.toString();
-                    }
-                }
-                if (!StringUtils.hasText(detectedLanguage)) {
-                    log.warn("Detected language is empty for discussion ID: {}", id);
-                    handleLanguageDetectionFailure(discussionDetailsNode, id, Constants.LANGUAGE_NOT_DETECTED);
-                    return;
-                }
+                detectedLanguage = detectLanguage(detectedLanguage, discussionDetailsNode, id, text);
+                if (detectedLanguage == null) return;
                 discussionDetailsNode.put(Constants.LANGUAGE, detectedLanguage);
                 profanityCheckService.processProfanityCheck(String.valueOf(id), discussionDetailsNode);
             } catch (JsonProcessingException e) {
@@ -111,5 +101,37 @@ public class LanguageDetectionConsumer {
             return new HashMap<>();
         }
         return langDetectResponse;
+    }
+
+
+    /**
+     * Detects the language of the given text using a language detection service.
+     * If the service call fails or returns an empty language, handles the failure accordingly.
+     *
+     * @param detectedLanguage the initially detected language (can be empty)
+     * @param discussionDetailsNode the details of the discussion as an ObjectNode
+     * @param id the ID of the discussion
+     * @param text the text for which language detection is to be performed
+     * @return the detected language, or null if detection failed
+     */
+    private String detectLanguage(String detectedLanguage, ObjectNode discussionDetailsNode, String id, String text) {
+        if (cbServerProperties.isEnableEnglishLanguageByDefault()) {
+            log.info("Setting default language as English for discussion ID: {}", id);
+            detectedLanguage = Constants.ENGLISH_LANGUAGE_CODE;
+        } else {
+            Map<String, Object> langDetectResponse = callLanguageDetectionService(discussionDetailsNode, id, text);
+            if (MapUtils.isNotEmpty(langDetectResponse)) {
+                Object lang = langDetectResponse.get(Constants.DETECTED_LANGUAGE);
+                if (lang != null) {
+                    detectedLanguage = lang.toString();
+                }
+            }
+            if (!StringUtils.hasText(detectedLanguage)) {
+                log.warn("Detected language is empty for discussion ID: {}", id);
+                handleLanguageDetectionFailure(discussionDetailsNode, id, Constants.LANGUAGE_NOT_DETECTED);
+                return null;
+            }
+        }
+        return detectedLanguage;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -102,4 +102,6 @@ kafka.topic.process.check.content.profanity=dev.process.check.content.profanity
 kafka.group.process.check.content.profanity=dev.process.check.content.profanity.group
 kafka.topic.process.detect.language=dev.process.detect.text.language
 kafka.group.process.detect.language=dev.process.detect.language.group
+# Flag to enable English language by default for content moderation
+enable.english.language.by.default=true
 


### PR DESCRIPTION
1.  enable.english.language.by.default - new attribute added in the application.properties.
2.  If this flag is set to true we would avoid calling the language detection API , it would hardcode the language detected as english - "en".
4.  If the flag is  set to false then we would be calling the language detection API and fetch the language code and then call the content moderation flow.